### PR TITLE
Update addon.xml

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -5,7 +5,7 @@
        provider-name="CaTz">
     <requires>
         <import addon="xbmc.python" version="2.14.0"/>
-		<import addon="script.module.beautifulsoup4" version="4.3.2"/>
+	<import addon="script.module.beautifulsoup" version="3.2.1"/>
     </requires>
     <extension point="xbmc.subtitle.module" library="service.py"/>
     <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
Hello it's me again :)
I posted about dependancy missing BeautifulSoup.
You added BS version 4 wich is not compatibile with this addon.
Of course I changed the service.py from:

from BeautifulSoup import BeautifulSoup

to:

from bs4 import BeautifulSoup 

As i saw in some XBMC forum topic. To make it use bs4.
But it crash with ERROR: list out of bound in log while scraping list of subs from site.

With BS v3 there's no problem and work 100% ok.
